### PR TITLE
fix: escape srcset

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -72,7 +72,7 @@ export function createImageApi (config: Config) {
           srcset: (
             await Promise.all(
               srcset.map(async ({ condition, args, generate }) => [
-                await getImageSrc(filename, { ...args, ...otherParams }, generate),
+                encodeURI(await getImageSrc(filename, { ...args, ...otherParams }, generate)),
                 condition,
               ].filter(x => x).join(' ')),
             )


### PR DESCRIPTION
if image filename is not escaped and contains, for example,
spaces, the resulting image won't load.