### PR TITLE
fix: use `this.emitFile` instead of mutating output bundle

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -78,7 +78,14 @@ export default function ImagePresetsPlugin (presets?: ImagePresets, options?: Op
     async generateBundle (_, output) {
       if (config.writeToBundle) {
         const images = await api.waitForImages()
-        images.forEach((asset) => { output[asset.fileName] = asset })
+        images.forEach((asset) => {
+          this.emitFile({
+            type: 'asset',
+            fileName: asset.fileName,
+            name: asset.name,
+            source: asset.source,
+          })
+        })
         api.purgeCache(images)
       }
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,12 +79,17 @@ export default function ImagePresetsPlugin (presets?: ImagePresets, options?: Op
       if (config.writeToBundle) {
         const images = await api.waitForImages()
         images.forEach((asset) => {
-          this.emitFile({
-            type: 'asset',
-            fileName: asset.fileName,
-            name: asset.name,
-            source: asset.source,
-          })
+          if (this.emitFile) {
+            this.emitFile({
+              type: 'asset',
+              fileName: asset.fileName,
+              name: asset.name,
+              source: asset.source,
+            })
+          }
+          else {
+            output[asset.fileName] = asset
+          }
         })
         api.purgeCache(images)
       }


### PR DESCRIPTION
Direct assignment to the bundle variable in `generateBundle` is discouraged by Rollup and unsupported by Rolldown. This commit fixes the issue by using the standard plugin context `this.emitFile` API instead.